### PR TITLE
allow all origins access

### DIFF
--- a/api/app/controllers/api/reports_controller.rb
+++ b/api/app/controllers/api/reports_controller.rb
@@ -4,6 +4,7 @@ module Api
   # Exposes the Report location and reason data
   class ReportsController < ApplicationController
     before_action :set_report, only: %i[show destroy]
+    before_action :set_headers
 
     # GET reports/:id
     def show
@@ -34,6 +35,12 @@ module Api
 
     def set_report
       @report = Report.find_by(id: params[:id])
+    end
+
+    def set_headers
+      headers['Access-Control-Allow-Origin'] = '*'
+      headers['Access-Control-Allow-Methods'] = 'POST, DELETE, GET'
+      headers['Access-Control-Request-Method'] = '*'
     end
 
     def report_params


### PR DESCRIPTION
Added access control headers for the reports controller including allowing all clients access without CORS restrictions.  This is OK for development but may need to change for beta and production.