### PR TITLE
replaced MySQL with PostgreSQL

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -14,19 +14,19 @@ jobs:
       working-directory: api
 
     services:
-      mysql:
-        image: mysql:8
+      postgres:
+        image: postgres:13
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          POSTGRES_PASSWORD: postgres
         ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - name: Inspect MySQL (on failure)
+      - name: Inspect PostgreSQL (on failure)
         run: |
           echo "${{ toJson(job) }}"
-          docker logs "${{ job.services.mysql.id }}"
+          docker logs "${{ job.services.postges.id }}"
         if: failure()
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-bundler-
       - name: Setup
         env:
-          DB_HOST: 127.0.0.1
+          DB_HOST: localhost
           RAILS_ENV: test
         run: |
           gem install bundler
@@ -62,7 +62,6 @@ jobs:
       - name: Upload Coverage Report
         run: |
           bash <(curl -s https://codecov.io/bash) -Z
-
   lint:
     name: Run Linter
     runs-on: ubuntu-latest

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -6,7 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
 # Use mysql as the database for Active Record
-gem 'mysql2', '>= 0.5.3'
+# gem 'mysql2', '>= 0.5.3'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -121,13 +121,13 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
-    mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    pg (1.2.3)
     public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
@@ -214,7 +214,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    spring (2.1.0)
+    spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -250,7 +250,7 @@ DEPENDENCIES
   faker (~> 2.11)
   launchy
   listen (~> 3.2)
-  mysql2 (>= 0.5.3)
+  pg
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec

--- a/api/ProcFile
+++ b/api/ProcFile
@@ -1,0 +1,1 @@
+web: bundle exec rails server -p 4000

--- a/api/README.md
+++ b/api/README.md
@@ -8,9 +8,9 @@ Built an deployed using the Ruby on Rails framework.
 
 1. [Ruby 2.5.8/Rails](https://bitnami.com/stack/ruby/installer)
 2. [Bundler](https://bundler.io/)
-3. [MySQL 8.0.x](https://dev.mysql.com/doc/refman/8.0/en/installing.html)
+3. [PostgreSQL 13.0.x](https://www.postgresql.org/download/)
 
-Note: The api connects to the local development MySQL server using the root user id and no password.
+Note: The api connects to the local development PostgreSLQ server using the root user id and no password.
 
 ## API application Initialization
 
@@ -48,7 +48,7 @@ After cloning the repo, navigate to /cbus-biking-LOC/api and enter:
 
 <pre>rails s</pre>
 
-This will start the application server on your localhost at port 3000. When running the ui, you may need to run on a different port:
+This will start the application server on your localhost at port 4000. When running the ui, you may need to run on a different port:
 
 <pre>rails s -p {port}</pre>
 
@@ -66,14 +66,14 @@ This will start the application server on your localhost at port 3000. When runn
 
 Swagger documentation for all API endpoints is made available through the [rswag gem] (https://github.com/rswag/rswag).  This documentation is generated from Request rspec tests that include schema information, required parameters and expected status codes for all supported HTTP methods. These methods can be invoked directly from the Swagger UI.
 
-The generated documentation (Swagger UI) is available at http://localhost:3000/api-docs/index.html after the cloning and initialization steps.  To use a different host or port than the default:
+The generated documentation (Swagger UI) is available at http://localhost:4000/api-docs/index.html after the cloning and initialization steps.  To use a different host or port than the default:
 
 1. Locate and modify the default host in the spec/swagger_helper.rb file as shown below:
 
 <pre>
 variables: {
             defaultHost: {
-              default: 'localhost:4000'
+              default: 'localhost:5000'
             }
 </pre>
 

--- a/api/bin/rails
+++ b/api/bin/rails
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 begin
   load File.expand_path('spring', __dir__)

--- a/api/bin/rake
+++ b/api/bin/rake
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 begin
   load File.expand_path('spring', __dir__)

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -1,26 +1,34 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# PostgreSQL. Versions 8.2 and up are supported.
 #
-# Install the MySQL driver
-#   gem install mysql2
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
 #
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
+# Configure Using Gemfile
+# gem 'pg'
 #
-# And be sure to use new-style password hashing:
-#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
-#
+
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
+  username: 
   password: 
   database: cbus_biking_loc_development
-  socket: /tmp/mysql.sock
+  # socket: /tmp/mysql.sock
 
 development:
   <<: *default
   database: cbus_biking_loc_development
+  host: localhost
+  port: 5432
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -19,8 +19,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: 
-  password: 
+  username: postgres
+  password: postgres
   database: cbus_biking_loc_development
   # socket: /tmp/mysql.sock
 

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -12,19 +12,23 @@
 
 ActiveRecord::Schema.define(version: 2020_09_14_212925) do
 
-  create_table "incident_severities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  #create_table "incident_severities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "incident_severities", force: :cascade do |t|
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "incident_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  #create_table "incident_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "incident_types", force: :cascade do |t|
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  #create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "reports", force: :cascade do |t|
+
     t.float "lat"
     t.float "long"
     t.datetime "incident_datetime"

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
           url: 'http://{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'localhost:3000'
+              default: 'localhost:4000'
             }
           }
         }

--- a/api/swagger/v1/swagger.yaml
+++ b/api/swagger/v1/swagger.yaml
@@ -282,4 +282,4 @@ servers:
 - url: http://{defaultHost}
   variables:
     defaultHost:
-      default: localhost:3000
+      default: localhost:4000


### PR DESCRIPTION
Changes required to switch database from MySQL to PostgreSQL to facilitate Heroku deploys.  No changes required for client except using PostgreSQL.  See README.md for details.

- added pg gem
- database.yml file configured to use PostgreSQL
- Removed options from schema.rb

Unrelated to database changes:
- Changed default port from 3000 to 4000
- Added Procfile for heroku deploys (more to do here)
